### PR TITLE
Evan/dw 103/add delete postcomment

### DIFF
--- a/components/Feed/NewPostForm.tsx
+++ b/components/Feed/NewPostForm.tsx
@@ -479,6 +479,13 @@ const NewPostForm: React.FC<NewPostProps> = ({ closeModal, questPlaceholder, des
         setExpanded(!expanded);
     }
 
+    const handleKeyPress = (e) => {
+        // Trigger on enter key
+        if (e.keyCode === 13) {
+            sendAndClose(e);
+        }
+    }
+
     return (
         <div className={postFormStyles.modalDiv}>
             <Dialog.Title as="div" className={postFormStyles.dialogTitle}>
@@ -670,8 +677,9 @@ const NewPostForm: React.FC<NewPostProps> = ({ closeModal, questPlaceholder, des
                 <Button text="Post" keepText={true} icon={<UilNavigator/>}
                     type="submit"
                     addStyle={postFormStyles.PostButton}
-                    onClick={sendAndClose}/>
-            </div>
+                    onClick={sendAndClose}
+                    onKeyPress={handleKeyPress}/>
+        </div>
         </div>
     );
 };

--- a/components/Feed/NewPostForm.tsx
+++ b/components/Feed/NewPostForm.tsx
@@ -231,12 +231,12 @@ const NewPostForm: React.FC<NewPostProps> = ({ closeModal, questPlaceholder, des
 
         // Prepare the data to add as a post
         let postData = {
-            message: inputRef.current.value,                    // Leaving field name as message even though UI refers to it as a question
-            description: descriptionRef.current.value,          // Optional description
+            message: inputRef.current.value,                            // Leaving field name as message even though UI refers to it as a question
+            description: descriptionRef.current.value,                  // Optional description
             name: userData.username ? userData.username : user.email,   // Change this with username or incognito
-            image: userData.photoUrl ? userData.photoUUrl : null,                               // Change this with profile picture or incognito
-            uid: user.uid,                                      // uid of the user that created this post
-            isCompare: false,                                   // Explicitly flag whether is compare type
+            image: userData.photoUrl ? userData.photoUUrl : null,       // Change this with profile picture or incognito
+            uid: user.uid,                                              // uid of the user that created this post
+            isCompare: false,                                           // Explicitly flag whether is compare type
             timestamp: firebase.firestore.FieldValue.serverTimestamp(),
         }
 

--- a/components/Feed/NewPostForm.tsx
+++ b/components/Feed/NewPostForm.tsx
@@ -13,9 +13,10 @@ import { Collapse } from '@mui/material';
 
 // Form management
 import { useForm } from 'react-hook-form';
-// import FlashErrorMessage from '../Utils/FlashErrorMessage';
 import useTimeout from '../../hooks/useTimeout';
 import { UilExclamationTriangle } from '@iconscout/react-unicons';
+import { useDocumentData } from 'react-firebase-hooks/firestore';
+import { doc } from 'firebase/firestore';
 
 const postFormStyles = {
     modalDiv: 'flex-col bg-white dark:bg-neutralDark-500',
@@ -63,6 +64,7 @@ type NewPostProps = {
 
 const NewPostForm: React.FC<NewPostProps> = ({ closeModal, questPlaceholder, descPlaceholder }) => {
     const [user] = useAuthState(auth);
+    const [userData] = useDocumentData(doc(db, "users", user.uid));
 
     // Form management
     const { register, setError, formState: { errors } } = useForm();
@@ -229,12 +231,12 @@ const NewPostForm: React.FC<NewPostProps> = ({ closeModal, questPlaceholder, des
 
         // Prepare the data to add as a post
         let postData = {
-            message: inputRef.current.value,            // Leaving field name as message even though UI refers to it as a question
-            description: descriptionRef.current.value,  // Optional description
-            name: user.name ? user.name : user.email,   // Change this with username or incognito
-            image: user.photoURL,                       // Change this with profile picture or incognito
-            uid: user.uid,                              // uid of the user that created this post
-            isCompare: false,                           // Explicitly flag whether is compare type
+            message: inputRef.current.value,                    // Leaving field name as message even though UI refers to it as a question
+            description: descriptionRef.current.value,          // Optional description
+            name: userData.username ? userData.username : user.email,   // Change this with username or incognito
+            image: userData.photoUrl ? userData.photoUUrl : null,                               // Change this with profile picture or incognito
+            uid: user.uid,                                      // uid of the user that created this post
+            isCompare: false,                                   // Explicitly flag whether is compare type
             timestamp: firebase.firestore.FieldValue.serverTimestamp(),
         }
 
@@ -660,17 +662,17 @@ const NewPostForm: React.FC<NewPostProps> = ({ closeModal, questPlaceholder, des
 
             {/* Cancel / Submit buttons */}
             <div className="inline-flex w-full space-x-3 px-2">
-                    <Button text="Cancel" keepText={true} icon={null}
-                        type='button' 
-                        addStyle={postFormStyles.cancelButton}
-                        onClick={closeModal}
-                    />
-                    <Button text="Post" keepText={true} icon={<UilNavigator/>}
-                        type="submit"
-                        addStyle={postFormStyles.PostButton}
-                        onClick={sendAndClose}/>
-                </div>
+                <Button text="Cancel" keepText={true} icon={null}
+                    type='button' 
+                    addStyle={postFormStyles.cancelButton}
+                    onClick={closeModal}
+                />
+                <Button text="Post" keepText={true} icon={<UilNavigator/>}
+                    type="submit"
+                    addStyle={postFormStyles.PostButton}
+                    onClick={sendAndClose}/>
             </div>
+        </div>
     );
 };
 
@@ -680,3 +682,7 @@ NewPostForm.defaultProps = {
 }
 
 export default NewPostForm;
+
+function useRecoilState(userProfileState: any): [any, any] {
+    throw new Error('Function not implemented.');
+}

--- a/components/Feed/PostCard.tsx
+++ b/components/Feed/PostCard.tsx
@@ -83,29 +83,36 @@ const PostCard: React.FC<PostProps> = ({ postUid, id, name, message, description
     // setters of number of votes for a comparison
     // post
     useEffect(() => {
+        // Store reference to snapshot
         db.collection("posts")
-        .doc(id)
-        .onSnapshot((snapshot) => {
-            const postData = snapshot.data();
-            if (isComparePost(postData)) {
-                // Add a counter of votes for each object to compare.
-                // Note: this should generally be an array of 2 objects
-                let votesCounter = new Array(
-                    postData.compare.votesObjMapList.length
-                ).fill(0);
-                for (var i = 0; i < votesCounter.length; i++) {
-                    votesCounter[i] = Object.keys(
-                    postData.compare.votesObjMapList[i]
-                    ).length;
+            .doc(id)
+            .onSnapshot((snapshot) => {
+                const postData = snapshot.data();
+                if (postData) { // prevent error on compare post deletion
+                                // Probably not a permanent fix, may want to 
+                                // look at listening only for changes in the children elements
+                                // to avoid issues during post deletion
+                    if (isComparePost(postData)) {
+                        // Add a counter of votes for each object to compare.
+                        // Note: this should generally be an array of 2 objects
+                        let votesCounter = new Array(
+                            postData.compare.votesObjMapList.length
+                        ).fill(0);
+                        for (var i = 0; i < votesCounter.length; i++) {
+                            votesCounter[i] = Object.keys(
+                            postData.compare.votesObjMapList[i]
+                            ).length;
+                        }
+    
+                        // Update the vote counter
+                        setVotesList(votesCounter);
+    
+                        // Add compare data to state
+                        setCompareData(postData.compare.objList);
+                    }
                 }
+            });
 
-                // Update the vote counter
-                setVotesList(votesCounter);
-
-                // Add compare data to state
-                setCompareData(postData.compare.objList);
-            }
-        });
     }, []);
 
     // Event hooks

--- a/components/Feed/PostOptionsDropdown.tsx
+++ b/components/Feed/PostOptionsDropdown.tsx
@@ -1,0 +1,214 @@
+import React, { useState } from 'react';
+import Button from '../Utils/Button';
+import DropdownMenu from '../Utils/DropdownMenu';
+import { UilQuestionCircle, UilExclamationCircle, UilBan, UilTrashAlt, UilEllipsisH} from '@iconscout/react-unicons'
+import { auth, db } from '../../firebase';
+import Modal from '../Utils/Modal';
+import { Dialog } from '@headlessui/react';
+import { useDocumentData } from 'react-firebase-hooks/firestore';
+import { useAuthState } from 'react-firebase-hooks/auth';
+import { doc } from 'firebase/firestore';
+
+// Styles
+const postOptionsDropdownStyles = {
+    // Dropdown menu
+    menuButtonClass: "absolute top-sm right-sm text-neutral-700 cursor-pointer",
+    menuItemsClass: "absolute right-6 w-auto h-auto mt-2 p-2 origin-top-right \
+        bg-white dark:bg-neutralDark-500 rounded-md shadow-lg \
+        ring-2 ring-primary dark:ring-white ring-opacity-50 focus:outline-none before:font-bold",
+    buttonAddStyle: "items-center space-x-2 px-sm text-neutral-700 dark:text-neutralDark-150 \
+        hover:font-bold active:font-bold dark:hover:font-bold dark:active:font-bold \
+        hover:text-neutral-700 dark:hover:text-neutralDark-150 active:text-primary dark:active:text-primaryDark",
+    // Delete post confirmation modal
+    modalDiv: "flex-col bg-white dark:bg-neutralDark-500",
+    modalTitle: "flex px-2 py-md text-lg font-bold  text-neutral-800 dark:text-neutralDark-50",
+    modalCancelButton: "rounded-[20px] p-sm w-full justify-center bg-neutral-150 hover:bg-neutral-300\
+    text-neutral-700 text-sm font-bold",
+    modalConfirmButton: "rounded-[20px] p-sm w-full space-x-2 justify-center bg-alert dark:bg-alertDark\
+    hover:bg-error active:bg-error dark:hover:bg-errorDark \
+    dark:active:bg-errorDark text-white dark:text-white font-bold"
+}
+
+type PostOptionsDropdownProps = {
+    postUid: string, // Post author id
+    deletePost:  React.MouseEventHandler<HTMLButtonElement> // Handler function to delete post
+    authorName: string, // Post author name
+}
+
+const PostOptionsDropdown: React.FC<PostOptionsDropdownProps> = ({ postUid, deletePost, authorName }) => {
+    const [user] = useAuthState(auth);
+    const [userData] = useDocumentData(doc(db, "users", user.uid));
+    const [isOpen, setIsOpen] = useState(false)
+
+    // Helper Functions
+    const openModal = () => {
+        setIsOpen(true)
+    }
+
+    const closeModal = () => {
+        setIsOpen(false)
+    }
+
+    const isUsersOwnPost = (postUid) => {
+        return user?.uid === postUid
+    }
+
+    const isUserBlocked = (postUid) => {
+        return userData?.blockedUsers?.includes(postUid)
+    }
+
+    // Handler functions
+    const blockUser = (e) => {
+        e.preventDefault();
+
+        // Return early if user already blocked
+        console.log(user.posts);
+        if (isUserBlocked(postUid)) {
+            return
+        }
+
+        // Otherwise add blocked user uid to current user's
+        // blockedUsers array
+        // Why is this needed?
+        // The alternative is to create a separate collection for blocked
+        // users which maps  user's uid to an array of blocked user uids
+        // Storing this as an attribute under the user collection is more 
+        // efficient because we will need to store the current user attribuutes
+        // in global state
+        db.collection("users")
+        .doc(user.uid)
+        .get()
+        .then((userDoc) => {
+            let tmp = userDoc.data();
+
+            if ("blockedUsers" in tmp) {
+                tmp.blockedUsers.push(postUid)
+            } else {
+                // Create a new array
+                tmp["blockedUsers"] = [postUid]
+            }
+
+            userDoc.ref.update(tmp);
+        })
+        .catch((err) => {console.log(err)})
+    }
+
+    const unblockUser = (e) => {
+        e.preventDefault();
+
+        // Return early if user not blocked
+        if (!isUserBlocked(postUid)) {
+            return
+        }
+
+        // Remove blocked user uid from current user's 
+        // blockedUser list
+        db.collection("users")
+        .doc(user.uid)
+        .get()
+        .then((userDoc) => {
+            let tmp = userDoc.data();
+            const index = tmp.blockedUsers.indexOf(postUid);
+            if (index > -1) {
+                tmp.blockedUsers.splice(index, 1);
+                userDoc.ref.update(tmp);
+            }
+        })
+        .catch((err) => {console.log(err)})
+    }
+
+    const deleteAndClose = (e) => {
+        e.preventDefault();
+        deletePost(e);
+        closeModal();
+    }
+
+    // Confirm delete post modal component
+    const ConfirmDeletePost = () => {
+
+        return (
+            <div className={postOptionsDropdownStyles.modalDiv}>
+                <Dialog.Title as="div" className={postOptionsDropdownStyles.modalTitle}>
+                    Are you sure you want to delete your post? It will be gone forever.
+                </Dialog.Title>
+                
+                {/* Cancel / Submit buttons */}
+                <div className="inline-flex w-full space-x-3 px-2">
+                    <Button text="No" keepText={true} icon={null}
+                        type='button' 
+                        addStyle={postOptionsDropdownStyles.modalCancelButton}
+                        onClick={closeModal}
+                    />
+                    <Button text="Yes, delete" keepText={true} icon={<UilTrashAlt/>}
+                        type="submit"
+                        addStyle={postOptionsDropdownStyles.modalConfirmButton}
+                        onClick={deleteAndClose}/>
+                </div>
+            </div>
+        )
+    }
+
+    const needsHook = () => {
+        alert('This button needs a hook!')
+    }
+
+    // Dropdown menu props
+    const menuButton = <UilEllipsisH/>
+    const ownPostMenuItems = [
+        <Button 
+            text="Delete Post"
+            keepText={true}
+            icon={<UilTrashAlt/>}
+            type="button"
+            onClick={openModal}
+            addStyle={postOptionsDropdownStyles.buttonAddStyle}
+        />
+    ]
+    const otherPostMenuItems = [
+        <Button 
+            text="Not Interested in This Post"
+            keepText={true}
+            icon={<UilQuestionCircle/>}
+            type="button"
+            onClick={needsHook}
+            addStyle={postOptionsDropdownStyles.buttonAddStyle}
+        />,
+        // TODO: Get more input on business logic. Does not make sense to be able to unblock 
+        // a user you've previous blocked froom within their posts. Presumably, you wouldn't see
+        // a blocked user's posts...
+        <Button 
+            text={`${isUserBlocked(postUid) ? 'Unblock' : 'Block'} ${authorName}`}
+            keepText={true}
+            icon={<UilBan/>}
+            type="button"
+            onClick={isUserBlocked(postUid) ? unblockUser : blockUser}
+            addStyle={postOptionsDropdownStyles.buttonAddStyle}
+        />,
+        <Button 
+            text="Report"
+            keepText={true}
+            icon={<UilExclamationCircle/>}
+            type="button"
+            onClick={needsHook}
+            addStyle={postOptionsDropdownStyles.buttonAddStyle}
+        />
+    ]
+
+    return (
+            <>
+            <DropdownMenu 
+                menuButtonClass={postOptionsDropdownStyles.menuButtonClass}
+                menuItemsClass={postOptionsDropdownStyles.menuItemsClass}
+                menuButton={menuButton}
+                menuItems={isUsersOwnPost(postUid) ? ownPostMenuItems : otherPostMenuItems}
+            />
+            <Modal 
+                children={<ConfirmDeletePost/>}
+                show={isOpen}
+                onClose={closeModal}
+            />
+            </>
+    )
+};
+
+export default PostOptionsDropdown;

--- a/components/Feed/PostsAPI.js
+++ b/components/Feed/PostsAPI.js
@@ -9,13 +9,13 @@ function PostsAPI({ posts }) {
   );
 
   return (
-    <div className="flex flex-col space-y-md">
+    <div className='flex flex-col space-y-md'>
       {realtimePosts
         ? realtimePosts?.docs.map((post) => (
             <PostCard
               key={post.id}
               id={post.id}
-              postOwner={post.data().uid}
+              postUid={post.data().uid}
               name={post.data().name}
               message={post.data().message}
               description={post.data().description}
@@ -31,7 +31,7 @@ function PostsAPI({ posts }) {
             <PostCard
               key={post.id}
               id={post.id}
-              postOwner={post.uid}
+              postUid={post.uid}
               name={post.name}
               message={post.message}
               description={post.description}

--- a/components/Header/SettingsButton.tsx
+++ b/components/Header/SettingsButton.tsx
@@ -7,12 +7,16 @@ interface SettingsButtonProps {
 }
 
 const SettingsButton: React.FC<SettingsButtonProps> = ({ hasText }) => {
-    // TODO: Add Hooks / link href
+    const needsHook = () => {
+        alert('This button needs a hook!')
+    }
 
     return (
-        <Link href='#' passHref>
-            <a className='inline-flex group-hover:text-black active:text-black dark:group-hover:text-neutralDark-50 
-            dark:active:text-neutralDark-50'>
+        <Link href='#'  passHref>
+            <a 
+                onClick={needsHook}
+                className='inline-flex group-hover:text-black active:text-black dark:group-hover:text-neutralDark-50 
+                    dark:active:text-neutralDark-50'>
                 <UilSetting className="mx-1"/>
             {hasText && 'Settings'}
             </a>

--- a/components/Header/UserDropdown.tsx
+++ b/components/Header/UserDropdown.tsx
@@ -1,51 +1,36 @@
-import React, { Fragment } from 'react'
-import { Menu, Transition } from '@headlessui/react'
+import React from 'react'
 import { Avatar } from '@mui/material'
 import SettingsButton from './SettingsButton';
 import ToggleTheme from './ToggleTheme';
 import LogoutButton from './LogoutButton';
+import DropdownMenu from '../Utils/DropdownMenu';
 
-interface UserDropdownProps {
-    
-}
 
-const UserDropdown: React.FC = (props: UserDropdownProps) => {
-    const menuButtonClass: string = "inline-flex font-medium bg-transparent"
-    const menuItemsClass: string = "absolute right-6 w-48 h-auto mt-2 p-2 origin-top-right \
+// Styles
+const UserDropdownStyles = {
+    menuButtonClass: "inline-flex font-medium bg-transparent",
+    menuItemsClass: "absolute right-6 w-48 h-auto mt-2 p-2 origin-top-right \
         bg-white dark:bg-neutralDark-500 divide-y divide-neutral-300 dark:divide-neutralDark-300 rounded-md shadow-lg \
         ring-2 ring-primary dark:ring-white ring-opacity-50 focus:outline-none"
+}
 
-    return (
-        <Menu as="div" >
-            <Menu.Button className={menuButtonClass}>
-            <Avatar
-            className='hover:opacity-80 hover:scale-125 md:h-12 md:w-12 cursor-pointer'
-            src={"https://cdn-icons-png.flaticon.com/512/2395/2395608.png"}
+const UserDropdown: React.FC = () => {
+    // Dropdown menu props
+    const menuButton = <Avatar
+        className='hover:opacity-80 hover:scale-125 md:h-12 md:w-12 cursor-pointer'
+        src={"https://cdn-icons-png.flaticon.com/512/2395/2395608.png"}/>
+    const menuItems = [
+        <SettingsButton hasText={true}/>,
+        <LogoutButton hasText={true}/>,
+        <ToggleTheme hasText={true}/>
+    ]
+
+    return <DropdownMenu 
+                menuButtonClass={UserDropdownStyles.menuButtonClass}
+                menuItemsClass={UserDropdownStyles.menuItemsClass}
+                menuButton={menuButton}
+                menuItems={menuItems}
             />
-            </Menu.Button>
-            <Transition
-            as={Fragment}
-                enter="transition duration-100 ease-out"
-                enterFrom="transform scale-95 opacity-0"
-                enterTo="transform scale-100 opacity-100"
-                leave="transition duration-75 ease-in"
-                leaveFrom="transform scale-100 opacity-100"
-                leaveTo="transform scale-95 opacity-0"
-            >
-                <Menu.Items as="ul" className={menuItemsClass}>
-                    <Menu.Item as="li" className="pt-1 group">
-                        <SettingsButton hasText={true}/>
-                    </Menu.Item>
-                    <Menu.Item as="li" className="pt-1 group">
-                        <LogoutButton hasText={true}/>
-                    </Menu.Item>
-                    <Menu.Item as="li" className="pt-1 group"> 
-                        <ToggleTheme hasText={true}/>
-                    </Menu.Item>
-                </Menu.Items>
-            </Transition>
-        </Menu>
-    )
 }
 
 export default UserDropdown

--- a/components/ProfileSettings.js
+++ b/components/ProfileSettings.js
@@ -38,10 +38,27 @@ function ProfileSettings({ userProfile }) {
         tmp.allowDM = dm;
 
         doc.ref.update(tmp);
+      });
+
+    // Update user
+    db.collection("users")
+      .doc(userProfile.uid)
+      .get()
+      .then((doc) => {
+        let tmp = doc.data();
+        tmp.name = name + (name && last) ? " " : "" + last;
+        tmp.username = username;
+        // TODO -> ADD THE LOGIC TO UPLOAD PICTURE AS PER POST
+        // tmp.photoURL = "";
+
+        doc.ref.update(tmp);
 
         // After update push the router to the feed
         router.push(`/feed/${userProfile.uid}`);
       });
+
+    // TODO: We should also be updating the auth user profile
+    // user.updateProfile({ ...}).then(())
   };
 
   const cancelAndContinue = (e) => {
@@ -62,87 +79,87 @@ function ProfileSettings({ userProfile }) {
   };
 
   return (
-    <div className="flex flex-col w-full items-center justify-center">
+    <div className='flex flex-col w-full items-center justify-center'>
       <Head>
         <title>Profile settings</title>
       </Head>
-      <h1 className="mt-5">User Profile settings</h1>
-      <div className="flex w-1/2 mt-10 items-center justify-center">
+      <h1 className='mt-5'>User Profile settings</h1>
+      <div className='flex w-1/2 mt-10 items-center justify-center'>
         <Image
-          className="top-0"
+          className='top-0'
           src={userProfile.profilePic}
           height={84}
           width={84}
         />
-        <form className="flex flex-grow flex-col items-center">
+        <form className='flex flex-grow flex-col items-center'>
           <p>Username</p>
           <input
             onChange={(e) => {
               setUsername(e.target.value);
             }}
             value={username}
-            className="flex-grow w-full p-2 ml-5 rounded-md focus:outline-none"
-            type="text"
+            className='flex-grow w-full p-2 ml-5 rounded-md focus:outline-none'
+            type='text'
           />
-          <div className="flex ml-3">
-            <div className="flex flex-col items-center">
-              <p className="mt-3">First name</p>
+          <div className='flex ml-3'>
+            <div className='flex flex-col items-center'>
+              <p className='mt-3'>First name</p>
               <input
                 onChange={(e) => {
                   setName(e.target.value);
                 }}
                 value={name}
-                className="p-2 w-4/5 rounded-md focus:outline-none"
-                type="text"
+                className='p-2 w-4/5 rounded-md focus:outline-none'
+                type='text'
               />
             </div>
-            <div className="flex flex-col items-center">
-              <p className="mt-3">Last name</p>
+            <div className='flex flex-col items-center'>
+              <p className='mt-3'>Last name</p>
               <input
                 onChange={(e) => {
                   setLast(e.target.value);
                 }}
                 value={last}
-                className="p-2 w-4/5 rounded-md focus:outline-none"
-                type="text"
+                className='p-2 w-4/5 rounded-md focus:outline-none'
+                type='text'
               />
             </div>
           </div>
-          <p className="mt-3">Location</p>
+          <p className='mt-3'>Location</p>
           <input
             onChange={(e) => {
               setLocation(e.target.value);
             }}
             value={location}
-            className="flex-grow w-full p-2 ml-5 rounded-md focus:outline-none"
+            className='flex-grow w-full p-2 ml-5 rounded-md focus:outline-none'
             placeholder={"Wonderland"}
-            type="text"
+            type='text'
           />
-          <p className="mt-3">Bio</p>
+          <p className='mt-3'>Bio</p>
           <input
             onChange={(e) => {
               setBio(e.target.value);
             }}
             value={bio}
-            className="flex-grow w-full p-2 ml-5 rounded-md focus:outline-none"
+            className='flex-grow w-full p-2 ml-5 rounded-md focus:outline-none'
             placeholder={"Something about yourself..."}
-            type="text"
+            type='text'
           />
-          <div className="flex items-center">
-            <button className="btn mt-3" onClick={toggleDM}>
+          <div className='flex items-center'>
+            <button className='btn mt-3' onClick={toggleDM}>
               Allow DM
             </button>
             {dm ? (
-              <p className="mt-3 ml-3">DM enabled</p>
+              <p className='mt-3 ml-3'>DM enabled</p>
             ) : (
-              <p className="mt-3 ml-3">DM disabled</p>
+              <p className='mt-3 ml-3'>DM disabled</p>
             )}
           </div>
-          <div className="flex items-center">
-            <button className="btn mt-3 mr-3" onClick={cancelAndContinue}>
+          <div className='flex items-center'>
+            <button className='btn mt-3 mr-3' onClick={cancelAndContinue}>
               Cancel
             </button>
-            <button className="btn mt-3" onClick={saveAndContinue}>
+            <button className='btn mt-3' onClick={saveAndContinue}>
               Save and continue
             </button>
           </div>

--- a/components/Utils/DropdownMenu.tsx
+++ b/components/Utils/DropdownMenu.tsx
@@ -1,0 +1,49 @@
+import { Menu, Transition } from '@headlessui/react';
+import React, { Fragment } from 'react';
+
+type DropdownMenuProps = {
+    menuButtonClass: string,
+    menuItemsClass: string,
+    menuButton: Any,
+    menuItems: Array<T>
+};
+
+const DropdownMenu: React.FC<DropdownMenuProps> = (
+    {
+        menuButtonClass,
+        menuItemsClass,
+        menuButton,
+        menuItems
+    }
+) => {
+  return (
+        <Menu as="div" >
+        <Menu.Button className={menuButtonClass}>
+            {menuButton}
+        </Menu.Button>
+        <Transition
+        as={Fragment}
+            enter="transition duration-100 ease-out"
+            enterFrom="transform scale-95 opacity-0"
+            enterTo="transform scale-100 opacity-100"
+            leave="transition duration-75 ease-in"
+            leaveFrom="transform scale-100 opacity-100"
+            leaveTo="transform scale-95 opacity-0"
+        >
+            <Menu.Items as="ul" className={menuItemsClass}>
+                {menuItems.map(
+                    (item, idx) => {
+                        return (
+                            <Menu.Item key={idx} as="li" className="pt-1 group">
+                                {item}
+                            </Menu.Item>
+                        )
+                    }
+                )}
+            </Menu.Items>
+        </Transition>
+    </Menu>
+  );
+};
+
+export default DropdownMenu;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -55,8 +55,8 @@ module.exports = {
         primaryDark: "#7269FF",
         secondaryDark: "#FB9393",
         alertDark: "#FB8C4E",
-        error: "#FA3541",
-        success: "#3DDE88",
+        errorDark: "#FA3541",
+        successDark: "#3DDE88",
         neutralDark: {
           50: "#E4E6EB",
           150: "#B0B3B8",


### PR DESCRIPTION
Closes dework #103

## Changes
Primarily implements the 'more' dropdown menu for posts. See these [flows](https://www.figma.com/file/Tur7BcWjVW9F6xfFY0jsRG/Oogway?node-id=488%3A6975) on Figma.

More dropdown:
- For one's own post, the only option is to delete which requires confirmation via a modal
- For other's posts, I added the 'not interested', 'block <username>' and report options
    -  The not interested and report options have no hooks at the moment because their business logic is underdeveloped
    -  For block, I added an array to the "users" collection entitled `blockUser` which stores uid's of the blocked user. I also added an unblock function that removes 
 

## Notes
User entries in the users collection now update during the profile update so that we have their new username and photoUrl there as well. The snapshot in `PostCard.tsx` for tracking votes had a bug when A vs B posts were deleted. I fixed it with a simple if statement, but we may to update the snapshot so that it only detects changes in the post, not on all events (i.e. deletes).