### PR TITLE
remove toLocaleString() from SSR timestamps

### DIFF
--- a/pages/comments/[id].tsx
+++ b/pages/comments/[id].tsx
@@ -75,7 +75,7 @@ export async function getServerSideProps(context) {
     const post = {
         id: postRes.id,
         ...postRes.data(),
-        timestamp: postRes.data().timestamp.toDate().toLocaleString(), // DO NOT prefetch timestamp as is
+        timestamp: postRes.data().timestamp.toDate().getTime(),
     }
 
     // Prepare the comments

--- a/pages/feed/[id].tsx
+++ b/pages/feed/[id].tsx
@@ -48,13 +48,14 @@ export async function getServerSideProps(context) {
         .collection('posts')
         .orderBy('timestamp', 'desc')
         .get()
-    const profile = await db.collection('profiles').doc(context.query.id).get()
-
     const docs = posts.docs.map((post) => ({
         id: post.id,
         ...post.data(),
-        timestamp: null, // DO NOT prefetch timestamp
+        timestamp: posts.data().timestamp.toDate().getTime(), // DO NOT prefetch timestamp
     }))
+
+    // Get user profile
+    const profile = await db.collection('profiles').doc(context.query.id).get()
     const userProfile = profile.data()
 
     return {


### PR DESCRIPTION
The timestamp bug was with one of the methods---toLocaleString()---we were calling on the SSR timestamps, not the parser. Should be good to go.