### PR TITLE
fix firebase v8 holder syntax to v9

### DIFF
--- a/lib/storageHelper.ts
+++ b/lib/storageHelper.ts
@@ -1,11 +1,11 @@
 import { storage } from "../firebase"
-import { ref, listAll } from '@firebase/storage'
+import { ref, listAll, deleteObject } from '@firebase/storage'
 
 export const deleteMedia = (path: string) => {
     const mediaRef = ref(storage, path)
     listAll(mediaRef).then((listResults) => {
         const promises = listResults.items.map((item) => {
-            return item.delete()
+            return deleteObject(item);
         })
         Promise.all(promises)
     })


### PR DESCRIPTION
The delete media helper was using old, broken syntax to delete images and therefore deleting them. I updated to v9.