### PR TITLE
Adding missing glob for .ts files in tailwind config

### DIFF
--- a/styles/profile.ts
+++ b/styles/profile.ts
@@ -17,12 +17,13 @@ export const profileCard = {
         dark:active:bg-primaryActive \
         text-white font-bold text-base leading-5 not-italic tracking-normal",
     editButton:
-        "text-neutral-700 dark:text-neutralDark-300 rounded-[20px] py-2 px-4 border-neutral-150 \
-        border-solid border font-bold text-sm leading-5 not-italic tracking-normal\
-        dark:bg-neutral-300 hover:bg-neutral-300\
-        active:bg-neutral-300",
-    joinedAndLocationText: 'text-neutral-700 dark:text-neutralDark-300 flex item-center font-normal text-sm md:text-base leading-6 tracking-normal text-gray-600 pt-1',
-    bioText: 'text-neutral-700 dark:text-neutralDark-150 font-normal text-sm md:text-base leading-6 text-left not-italic tracking-normal mx-3 md:mx-0 pt-1 whitespace-pre-line',
+        "text-neutral-700 dark:text-neutralDark-300 rounded-[20px] py-2 px-4 \
+        font-bold text-sm leading-5 not-italic tracking-normal \
+        bg-neutral-150 dark:bg-neutral-150 hover:bg-neutral-300 dark:hover:bg-neutralDark-150",
+    joinedAndLocationText: 'text-neutral-700 dark:text-neutralDark-300 flex item-center \
+        font-normal text-sm md:text-base leading-6 tracking-normal text-gray-600 pt-1',
+    bioText: 'text-neutral-700 dark:text-neutralDark-150 font-normal text-sm md:text-base \
+        leading-6 text-left not-italic tracking-normal mx-3 md:mx-0 pt-1 whitespace-pre-line',
     usernameText: 'text-primary dark:text-primaryDark',
 }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,7 @@ module.exports = {
     content: [
         './pages/**/*.{js,ts,jsx,tsx}',
         './components/**/*.{js,ts,jsx,tsx}',
-        './styles/*.js',
+        './styles/*.{js,ts}',
     ],
     darkMode: 'class',
     theme: {


### PR DESCRIPTION
Quick fix on the edit profile button style. A missing ".ts" glob in the tailwind config file was breaking styles.