### PR TITLE
if uid/userprofile missing, user cannot comment or post

### DIFF
--- a/components/Forms/NewCommentForm.tsx
+++ b/components/Forms/NewCommentForm.tsx
@@ -89,6 +89,9 @@ const NewCommentForm: React.FC<
     const addComment = async (e: MouseEvent<HTMLButtonElement>) => {
         e.preventDefault()
 
+        // return early if redux failed to fetch user
+        if (!userProfile.uid) return
+
         // Return asap if no input
         if (inputRef && !inputRef?.current?.value) {
             setError(

--- a/components/Forms/NewPostForm.tsx
+++ b/components/Forms/NewPostForm.tsx
@@ -174,17 +174,11 @@ const NewPostForm: FC<
 
     const [isInputTitle, setIsInputTitle] = useState<boolean>(false)
 
-    // I'm pretty sure this is introducing a memory leak
-    // useEffect cannot include async logic
     useEffect(() => {
-        if (previewImage) {
+        if (previewImage && userProfile.uid) {
             sendPost().finally()
         }
     }, [previewImage])
-
-    useEffect(() => {
-        console.log('currentFeed - ', selectedFeed)
-    }, [selectedFeed])
 
     // Update form selection
     const selectFeedHandler = (selectedOption: staticFeedOptions | null) => {
@@ -297,7 +291,11 @@ const NewPostForm: FC<
 
         // Whether to sendPost or not
         return (
-            questionProvided && feedProvided && questionHasMedia && !isTitleURL
+            questionProvided &&
+            feedProvided &&
+            questionHasMedia &&
+            !isTitleURL &&
+            userProfile.uid
         )
     }
 


### PR DESCRIPTION
Add if-else checks to protect against users w/ missing uids from making new posts or comments.

Still unclear whether this originates from a redux problem or problem with hand-off from auth0-->firebase during sign in.