### PR TITLE
Update criteria info cache after 3 weeks

### DIFF
--- a/components/Utils/Timestamp.tsx
+++ b/components/Utils/Timestamp.tsx
@@ -2,41 +2,18 @@ import { FieldValue } from 'firebase/firestore'
 import moment from 'moment'
 import React from 'react'
 
-interface TimeObject extends FieldValue {
-    seconds: number
-}
+import { parseTimestamp } from '../../utils/helpers/common'
+import { jsonTimeObj } from '../../utils/types/global'
+
 interface TimestampProps {
-    timestamp: FieldValue | Date | null
+    timestamp: FieldValue | Date | jsonTimeObj | null
 }
 
 const Timestamp = ({ timestamp }: TimestampProps) => {
-    // Utility to parse timestamp
-    const parseTimestamp = () => {
-        // Return early on missing timestamp
-        if (!timestamp) {
-            return
-        }
-
-        // If timestamp is a JSON time object, convert to date
-        // Otherwise assume it has already been converted on pre-fetch
-        if (!(timestamp instanceof Date) && timestamp instanceof Object) {
-            if (!('seconds' in timestamp)) {
-                return 'Cannot fetch time'
-            }
-            const timestampType: TimeObject = timestamp as TimeObject
-            if (timestampType && timestampType.seconds) {
-                timestamp = new Date(timestampType?.seconds * 1000 || '')
-            }
-        }
-
-        // Convert to fromNow time
-        return moment(timestamp).fromNow()
-    }
-
     return (
         <>
             {timestamp ? (
-                <p>{parseTimestamp()}</p>
+                <p>{moment(parseTimestamp(timestamp)).fromNow()}</p>
             ) : (
                 <p className="inline-flex text-neutral-700 dark:text-neutralDark-50">
                     loading

--- a/utils/constants/global.ts
+++ b/utils/constants/global.ts
@@ -40,3 +40,9 @@ export const decisionInfoParagraph = [
     'Oogway helps you when making a decision. All you have to do is put in your decision, and let Oogway help you come up with the best answer.',
     'Oogway reads through different web sources , and combines all the information together to give you the best answer.',
 ]
+
+/**
+ * Caching
+ */
+
+export const criteriaInfoCacheDays = 21


### PR DESCRIPTION
### Changes
- I now use a hashing algo to convert the "api version-decision option-criteria" tuple into a 53bit hash and use that as the firebase id
- If a user asks the AI for info on an option-criteria pair that already exists, it will be fetched from firebase. 
- If the cached data is greater than 21 days old, then the cached data won't be used and instead a new call will be made to the AI endpoint and that data will update the cache.
- Also solved some other issues with the way the loading state wasn't working when users switched between tabs (cached data would be present, but when they clicked on askAI front-end appeared stuck in permanent loading state)

### Branching / JIRA

-   [x] I have named this PR in the following format: [JIRA-ISSUE-NUMBER] - [description of the work done in this PR]
-   [x] I have created this PR through the following steps:

1. Fetched latest version of main (`git checkout main`)
2. Rebased my branch onto main if there are new updates to main (`git pull upstream main`->`git checkout main`->`git rebase main`)
3. Fixed any conflicts before pushing branch to main and creating PR

-   [x] I will follow the above steps every time I push new commits after review
